### PR TITLE
Allow auth token to be an additional parameter to query

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -199,7 +199,8 @@ export class S5Client {
       query: config.query,
     });
 
-    const url = `${urlReq}${config.authToken ? `?auth_token=${config.authToken}` : ''}`;
+    const separator = config.query ? "&" : "?";
+    const url = `${urlReq}${config.authToken ? `${separator}auth_token=${config.authToken}` : ""}`;
 
     // Build headers.
     const headers = buildRequestHeaders(config.headers, config.customUserAgent, config.customCookie, config.s5ApiKey);

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,6 +56,7 @@ export type CustomClientOptions = {
  */
 export type RequestConfig = CustomClientOptions & {
   endpointPath?: string;
+  endpointGetMetadata?: string;
   data?: FormData | Record<string, unknown>;
   url?: string;
   method?: Method;
@@ -194,6 +195,7 @@ export class S5Client {
     const urlReq = await buildRequestUrl(this, {
       baseUrl: config.url,
       endpointPath: config.endpointPath,
+      endpointGetMetadata: config.endpointGetMetadata,
       subdomain: config.subdomain,
       extraPath: config.extraPath,
       query: config.query,

--- a/src/request.ts
+++ b/src/request.ts
@@ -52,6 +52,7 @@ export async function buildRequestUrl(
   parts: {
     baseUrl?: string;
     endpointPath?: string;
+    endpointGetMetadata?: string;
     subdomain?: string;
     extraPath?: string;
     query?: { [key: string]: string | undefined };
@@ -71,6 +72,9 @@ export async function buildRequestUrl(
 
   if (parts.endpointPath) {
     url = makeUrl(url, parts.endpointPath);
+  }
+  if (parts.endpointGetMetadata) {
+    url = makeUrl(url, parts.endpointGetMetadata);
   }
   if (parts.extraPath) {
     url = makeUrl(url, parts.extraPath);


### PR DESCRIPTION
If config.query exists then the url already has a `?`, so need to instead add a `&` before appending the auth token to the url string.